### PR TITLE
chore: fix provider name on social auth btn

### DIFF
--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -721,7 +721,7 @@ function SocialAuth({
                       onClick={() => handleProviderSignIn(provider)}
                       className="flex items-center"
                     >
-                      {verticalSocialLayout && 'Sign up with ' + provider}
+                      {verticalSocialLayout && 'Sign up with ' + provider.charAt(0).toUpperCase() + provider.slice(1)}
                     </Button>
                   </div>
                 );


### PR DESCRIPTION
Capitalize first letter of provider name. 

So instead of `Sign in with google` it'll say `Sign in with Google`.

Just looks a bit more professional :+1: 

Otherwise, great job with this library!

P.S. it took me a bit to figure out I had to explicitly pass in the provider array to the `AuthModal` component to get them to show up. Might be helpful to mention that in the docs.