### PR TITLE
disable empty submit and switch to mouse down

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -134,7 +134,7 @@ const examples: Record<string, Example> = {
           onUserClick={(user) => {
             window.alert(user.name);
           }}
-          accentColor="#8405FF"
+          accentColor="#904a99"
         >
           <AuthModal
             visible={modalVisible}
@@ -167,7 +167,7 @@ const examples: Record<string, Example> = {
       onUserClick={(user) => {
         window.alert(user.name);
       }}
-      accentColor="#8405FF"
+      accentColor="#904a99"
     >
       <AuthModal
         visible={modalVisible}

--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -721,7 +721,10 @@ function SocialAuth({
                       onClick={() => handleProviderSignIn(provider)}
                       className="flex items-center"
                     >
-                      {verticalSocialLayout && 'Sign up with ' + provider.charAt(0).toUpperCase() + provider.slice(1)}
+                      {verticalSocialLayout &&
+                        'Sign up with ' +
+                          provider.charAt(0).toUpperCase() +
+                          provider.slice(1)}
                     </Button>
                   </div>
                 );

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -186,10 +186,10 @@ const CommentData: FC<CommentDataProps> = ({ comment }) => {
                   commentState.setValue(val);
                 }}
                 autoFocus={!!replyManager?.replyingTo}
-                actions={
+                actions={({ editor }) => (
                   <div className="flex mx-[3px] space-x-[3px]">
                     <Button
-                      onClick={() => {
+                      onMouseDown={() => {
                         setEditing(false);
                       }}
                       size="tiny"
@@ -199,7 +199,7 @@ const CommentData: FC<CommentDataProps> = ({ comment }) => {
                       Cancel
                     </Button>
                     <Button
-                      onClick={() => {
+                      onMouseDown={() => {
                         mutations.updateComment.mutate({
                           id: comment.id,
                           comment: commentState.value,
@@ -211,11 +211,12 @@ const CommentData: FC<CommentDataProps> = ({ comment }) => {
                       loading={mutations.updateComment.isLoading}
                       size="tiny"
                       className="!px-[6px] !py-[3px]"
+                      disabled={editor?.isEmpty}
                     >
                       Save
                     </Button>
                   </div>
-                }
+                )}
               />
             )}
           </p>

--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -111,9 +111,9 @@ const Comments: FC<CommentsProps> = ({ topic, parentId = null }) => {
                   commentState.setValue(val);
                 }}
                 autoFocus={!!replyManager?.replyingTo}
-                actions={
+                actions={({ editor }) => (
                   <Button
-                    onClick={() => {
+                    onMouseDown={(e) => {
                       runIfAuthenticated(() => {
                         mutations.addComment.mutate({
                           topic,
@@ -128,10 +128,11 @@ const Comments: FC<CommentsProps> = ({ topic, parentId = null }) => {
                     loading={mutations.addComment.isLoading}
                     size="tiny"
                     className="!px-[6px] !py-[3px] m-[3px]"
+                    disabled={isAuthenticated && editor?.isEmpty}
                   >
                     {!isAuthenticated ? 'Sign In' : 'Submit'}
                   </Button>
-                }
+                )}
               />
             </div>
           </div>

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from 'react';
+import React, { FC, forwardRef, ReactNode, useImperativeHandle } from 'react';
 import { IconBold, IconCode, IconItalic, IconList } from '@supabase/ui';
 import { useEditor, EditorContent } from '@tiptap/react';
 import clsx from 'clsx';
@@ -7,6 +7,7 @@ import StarterKit from '@tiptap/starter-kit';
 import MentionsExtension from './Mentions';
 import Placeholder from '@tiptap/extension-placeholder';
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
+import { Editor as EditorType } from '@tiptap/core';
 
 import styles from './Editor.module.css';
 // @ts-ignore
@@ -18,16 +19,19 @@ interface EditorProps {
   onChange?: (value: string) => void;
   readOnly?: boolean;
   autoFocus?: boolean;
-  actions?: ReactNode;
+  actions?: (params: { editor: EditorType | null }) => ReactNode;
 }
 
-const Editor: FC<EditorProps> = ({
-  defaultValue,
-  onChange,
-  readOnly = false,
-  autoFocus = false,
-  actions = null,
-}) => {
+const Editor: FC<EditorProps> = (
+  {
+    defaultValue,
+    onChange,
+    readOnly = false,
+    autoFocus = false,
+    actions = null,
+  },
+  ref
+) => {
   const context = useCommentsContext();
   const extensions: any[] = [
     StarterKit,
@@ -77,7 +81,7 @@ const Editor: FC<EditorProps> = ({
         <div
           className={clsx(
             'border-t-2 border-alpha-10',
-            'absolute bottom-0 left-0 right-0 flex items-center h-8'
+            'absolute bottom-0 left-0 right-0 flex items-center h-8 z-10'
           )}
         >
           <div
@@ -176,11 +180,10 @@ const Editor: FC<EditorProps> = ({
             </svg>
           </div>
           <div className="flex-1" />
-          <div>{actions}</div>
+          <div>{actions?.({ editor })}</div>
         </div>
       )}
     </div>
   );
 };
-
 export default Editor;

--- a/src/global.css
+++ b/src/global.css
@@ -268,6 +268,10 @@
   @apply bg-alpha !bg-opacity-100;
 }
 
+.tiptap-editor .sbui-btn:disabled {
+  opacity: 0.66;
+}
+
 .tiptap-editor .sbui-btn-primary {
   background-color: var(--sce-accent-500) !important;
   color: var(--sce-accent-50) !important;


### PR DESCRIPTION
This disables submission of empty comments.

Additionally there's some issue where if the tiptap editor is focused and you try to click submit, the button doesn't work on the first click. I suspect what's happening is that something is causing the button to remount on mouse down so the click event is not fired. For now i've switch the handlers to listen to mouse-down events instead. This is slightly strange ux, would like to figure it out and switch them back to click handlers once i figure out why the click handler is not firing with the tiptap editor in focus.